### PR TITLE
handle iOS interruptions

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -181,6 +181,7 @@ RCT_EXPORT_METHOD(release:(nonnull NSNumber*)key) {
     [player stop];
     [[self callbackPool] removeObjectForKey:player];
     [[self playerPool] removeObjectForKey:key];
+    [[self interruptionsPool] removeObjectForKey:key];
   }
 }
 


### PR DESCRIPTION
If you get a phone call during audio playback, the audio stops. There's no error callback or any other way for the author to know this has happened.

Here we keep track of which AVAudioPlayer instances have been interrupted (interruptionsPool) and when the interruptions end, we start them playing again.